### PR TITLE
Register BPAN Package github:chazmcgarvey/docker-connect

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -123,6 +123,16 @@ v0-1-10 = 332eb2a094f04df6b8c193725ae0c520ef58d575
 v0-1-11 = 28a4f36b730ca4955eec01430e3a47a287302705
 v0-1-12 = c8911940d2dfc9247edcbb8de8d3fa961f3e37e8
 
+[package "github:chazmcgarvey/docker-connect"]
+title = Easily connect to Docker sockets over SSH
+version = 0.82.2
+author = Charles McGarvey
+owner = chazmcgarvey
+license = MIT
+tags = bash bpan docker ssh
+date = Sun Oct 23 13:26:45 MDT 2022
+v0-82-2 = 86a849c87a7d362f51350b625e4fa4864aa9daae
+
 [package "github:ingydotnet/pst"]
 title = Package Super Tool — Package Management for All Programming Languages
 version = 0.1.9


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index/blob/main/index.ini):

    name:    docker-connect
    version: 0.82.2
    title:   Easily connect to Docker sockets over SSH
    author:  Charles McGarvey
    github:  chazmcgarvey