### PR TITLE
Register github:bpan-org/getopt-bash=0.1.23

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.100
-updated = 2022-12-15T20:22:41Z
+updated = 2022-12-15T20:23:02Z
 
 [default]
 host = github
@@ -39,3 +39,16 @@ author = https://github.com/ingydotnet
 update = 2022-12-15T20:22:41Z
 commit = b68c22072c441a85db0dfa24c322b0c403df29e8
 sha512 = 2dad80aedc07c4a3e7b1b54dda68d77737c364dd45aed49ccb86d08c73b78c3ea103c056cf4e0e8b34536bb5553cc690aa0261f76ef6683b5fc840fe36d8328c
+
+[package "github:bpan-org/getopt-bash"]
+title = Declarative getopt (long) parser
+version = 0.1.23
+license = MIT
+summary = ""
+type = bash-lib
+tag = ""
+source = https://github.com/bpan-org/getopt-bash/tree/0.1.23
+author = https://github.com/ingydotnet
+update = 2022-12-15T20:23:02Z
+commit = 36ad54fcdd8792803799230e1e350c7e1235fc36
+sha512 = cea769a11b276f1afcb1f8e57dc962e3c18f533c3e958515d434462539eca066eea453d8262d1c10f329468a603be71e821d2163bffbc49c4f0069fffef7a3f1


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-2022-12-15-20-22-32/blob/main/index.ini):

> https://github.com/bpan-org/getopt-bash/tree/0.1.23

    package: github:bpan-org/getopt-bash
    title:   Declarative getopt (long) parser
    version: 0.1.23
    license: MIT
    author:  https://github.com/ingydotnet