### PR TITLE
Register github:bpan-org/ini-bash=0.1.13

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.100
-updated = 2022-12-15T20:23:02Z
+updated = 2022-12-15T20:23:19Z
 
 [default]
 host = github
@@ -52,3 +52,16 @@ author = https://github.com/ingydotnet
 update = 2022-12-15T20:23:02Z
 commit = 36ad54fcdd8792803799230e1e350c7e1235fc36
 sha512 = cea769a11b276f1afcb1f8e57dc962e3c18f533c3e958515d434462539eca066eea453d8262d1c10f329468a603be71e821d2163bffbc49c4f0069fffef7a3f1
+
+[package "github:bpan-org/ini-bash"]
+title = Read and write to INI files from Bash
+version = 0.1.13
+license = MIT
+summary = ""
+type = bash-lib
+tag = ""
+source = https://github.com/bpan-org/ini-bash/tree/0.1.13
+author = https://github.com/ingydotnet
+update = 2022-12-15T20:23:19Z
+commit = 8cfc3783f5b5baa08b7654c3dddb31f0599a9497
+sha512 = eb8e0f9f2a1b3ebe8c4da617c444e17f88520033bcaccf796a6d49d775619c6205b058eb392f2e9968ee8a160078cb68faf751e38e6d8c6a2a34595273ff7493


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-2022-12-15-20-22-32/blob/main/index.ini):

> https://github.com/bpan-org/ini-bash/tree/0.1.13

    package: github:bpan-org/ini-bash
    title:   Read and write to INI files from Bash
    version: 0.1.13
    license: MIT
    author:  https://github.com/ingydotnet