### PR TITLE
Register github:bpan-org/test-tap-bash=0.1.21

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.100
-updated = 2022-12-15T20:23:19Z
+updated = 2022-12-15T20:23:33Z
 
 [default]
 host = github
@@ -65,3 +65,16 @@ author = https://github.com/ingydotnet
 update = 2022-12-15T20:23:19Z
 commit = 8cfc3783f5b5baa08b7654c3dddb31f0599a9497
 sha512 = eb8e0f9f2a1b3ebe8c4da617c444e17f88520033bcaccf796a6d49d775619c6205b058eb392f2e9968ee8a160078cb68faf751e38e6d8c6a2a34595273ff7493
+
+[package "github:bpan-org/test-tap-bash"]
+title = TAP Testing for Bash
+version = 0.1.21
+license = MIT
+summary = ""
+type = bash-lib
+tag = ""
+source = https://github.com/bpan-org/test-tap-bash/tree/0.1.21
+author = https://github.com/ingydotnet
+update = 2022-12-15T20:23:33Z
+commit = 725e29fbe3bf7c5b1d1bf16644cda6c48c02ed8e
+sha512 = 26be4f845d46f31704fb7cbdd36552bc54c4cc177e33de29c86f69b4e803092953ffed6c3ff7a7913f55914ff77eb2a1202ced2f5eb2f6ed7c354f12cecdf68e


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-2022-12-15-20-22-32/blob/main/index.ini):

> https://github.com/bpan-org/test-tap-bash/tree/0.1.21

    package: github:bpan-org/test-tap-bash
    title:   TAP Testing for Bash
    version: 0.1.21
    license: MIT
    author:  https://github.com/ingydotnet