### PR TITLE
Register github:bpan-org/md2man=0.1.27

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
 version = 0.1.100
-updated = 2022-12-15T20:23:33Z
+updated = 2022-12-15T20:23:50Z
 
 [default]
 host = github
@@ -65,6 +65,19 @@ author = https://github.com/ingydotnet
 update = 2022-12-15T20:23:19Z
 commit = 8cfc3783f5b5baa08b7654c3dddb31f0599a9497
 sha512 = eb8e0f9f2a1b3ebe8c4da617c444e17f88520033bcaccf796a6d49d775619c6205b058eb392f2e9968ee8a160078cb68faf751e38e6d8c6a2a34595273ff7493
+
+[package "github:bpan-org/md2man"]
+title = Markdown to man page converter
+version = 0.1.27
+license = MIT
+summary = ""
+type = bash-bin
+tag = ""
+source = https://github.com/bpan-org/md2man/tree/0.1.27
+author = https://github.com/ingydotnet
+update = 2022-12-15T20:23:50Z
+commit = 193378df0584a8ae1971ff6adb10c3bca6749127
+sha512 = 48fbf7ed133806d2bf6cda664c0decd7edc528264bbca3e9c0e9d409efa77e7d3aac30fb2a5386d88c633dd52c73c4faed3cedb8c1ce755bcc451990b3f7897d
 
 [package "github:bpan-org/test-tap-bash"]
 title = TAP Testing for Bash


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-2022-12-15-20-22-32/blob/main/index.ini):

> https://github.com/bpan-org/md2man/tree/0.1.27

    package: github:bpan-org/md2man
    title:   Markdown to man page converter
    version: 0.1.27
    license: MIT
    author:  https://github.com/ingydotnet