### PR TITLE
Register github:bpan-org/git-sha512=0.1.4

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.1.105
-updated = 2022-12-30T22:29:48Z
+version = 0.1.106
+updated = 2022-12-31T09:54:16Z
 
 [default]
 host = github
@@ -52,6 +52,19 @@ author = https://github.com/ingydotnet
 update = 2022-12-15T20:23:02Z
 commit = 36ad54fcdd8792803799230e1e350c7e1235fc36
 sha512 = cea769a11b276f1afcb1f8e57dc962e3c18f533c3e958515d434462539eca066eea453d8262d1c10f329468a603be71e821d2163bffbc49c4f0069fffef7a3f1
+
+[package "github:bpan-org/git-sha512"]
+title = Like 'git rev-parse' but using sha512
+version = 0.1.4
+license = MIT
+summary = 
+type = bash-bin
+tag = 
+source = https://github.com/bpan-org/git-sha512/tree/0.1.4
+author = https://github.com/ingydotnet
+update = 2022-12-31T09:54:16Z
+commit = d8eb86b6e4b224f16ca9a9b820a39e3a7ac5a718
+sha512 = 073391081d82e8779134b96513fea862f4d49d7f5c8090aa9a8fc0321f14cec89e36c272b70c59fdbb741b5c43dd2719e429845fd979765352aa2550de3a369f
 
 [package "github:bpan-org/ini-bash"]
 title = Read and write to INI files from Bash


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index/blob/main/index.ini):

> https://github.com/bpan-org/git-sha512/tree/0.1.4

    package: github:bpan-org/git-sha512
    title:   Like 'git rev-parse' but using sha512
    version: 0.1.4
    type:    bash-bin
    license: MIT
    author:  https://github.com/ingydotnet