### PR TITLE
Register github:bpan-org/git-sha512=0.1.5

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.1.105
-updated = 2022-12-30T22:29:48Z
+version = 0.1.106
+updated = 2022-12-31T12:47:51Z
 
 [default]
 host = github
@@ -31,9 +31,9 @@ MPL-2.0 \
 title = A Collection of Useful Bash Functions
 version = 0.1.68
 license = MIT
-summary = 
+summary = ""
 type = bash-lib
-tag = 
+tag = ""
 source = https://github.com/bpan-org/bashplus/tree/0.1.68
 author = https://github.com/ingydotnet
 update = 2022-12-30T22:26:59Z
@@ -53,13 +53,26 @@ update = 2022-12-15T20:23:02Z
 commit = 36ad54fcdd8792803799230e1e350c7e1235fc36
 sha512 = cea769a11b276f1afcb1f8e57dc962e3c18f533c3e958515d434462539eca066eea453d8262d1c10f329468a603be71e821d2163bffbc49c4f0069fffef7a3f1
 
+[package "github:bpan-org/git-sha512"]
+title = Like 'git rev-parse' but using sha512
+version = 0.1.5
+license = MIT
+summary = ""
+type = bash:bin
+tag = ""
+source = https://github.com/bpan-org/git-sha512/tree/0.1.5
+author = https://github.com/ingydotnet
+update = 2022-12-31T12:47:51Z
+commit = 643189ec5191cf483b74eb895f423f230097d07d
+sha512 = 57ff154ceede9a35eee62caf5a832963c34947a8055414eacdb37419c28044ab69a786f57090e7bef5b488aa72485ec032a3cece38ed1647eaa95aef49dcb761
+
 [package "github:bpan-org/ini-bash"]
 title = Read and write to INI files from Bash
 version = 0.1.15
 license = MIT
-summary = 
+summary = ""
 type = bash-lib
-tag = 
+tag = ""
 source = https://github.com/bpan-org/ini-bash/tree/0.1.15
 author = https://github.com/ingydotnet
 update = 2022-12-30T22:29:48Z
@@ -70,9 +83,9 @@ sha512 = 7dfee9d95fb433a138108904b849451b08aa5420313b5651702610d3e5b113d268fce49
 title = Markdown to man page converter
 version = 0.1.28
 license = MIT
-summary = 
+summary = ""
 type = bash-bin
-tag = 
+tag = ""
 source = https://github.com/bpan-org/md2man/tree/0.1.28
 author = https://github.com/ingydotnet
 update = 2022-12-21T23:10:15Z


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index/blob/main/index.ini):

> https://github.com/bpan-org/git-sha512/tree/0.1.5

    package: github:bpan-org/git-sha512
    title:   Like 'git rev-parse' but using sha512
    version: 0.1.5
    type:    bash:bin
    license: MIT
    author:  https://github.com/ingydotnet